### PR TITLE
Add Vitest-based tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "workspaces": [
     "packages/*"
   ],
+  "scripts": {
+    "test": "yarn workspace vecal test"
+  },
   "prettier": {
     "tabWidth": 4,
     "singleQuote": true,

--- a/packages/vecal/package.json
+++ b/packages/vecal/package.json
@@ -3,17 +3,18 @@
   "version": "0.0.1",
   "type": "module",
   "module": "./dist/vecal.es.js",
-  
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "devDependencies": {
     "@types/node": "^20.12.7",
     "jest": "^29.7.0",
     "path": "^0.12.7",
     "typescript": "^5.2.2",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^1.3.0"
   }
 }

--- a/packages/vecal/test/vector-db.test.ts
+++ b/packages/vecal/test/vector-db.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { VectorDB } from '../src';
+
+const CONFIG = { dbName: 'vitest-db', dimension: 3 };
+
+const VEC_APPLE = new Float32Array([0.9, 0.1, 0.1]);
+const VEC_BANANA = new Float32Array([0.1, 0.9, 0.1]);
+const VEC_CHERRY = new Float32Array([0.1, 0.1, 0.9]);
+const QUERY_VEC = new Float32Array([0.85, 0.2, 0.15]);
+
+let db: VectorDB;
+
+beforeEach(() => {
+  db = new VectorDB(CONFIG);
+});
+
+afterEach(() => {
+  indexedDB.deleteDatabase(CONFIG.dbName);
+});
+
+describe('VectorDB basic operations', () => {
+  it('adds and retrieves vectors', async () => {
+    const id = await db.add(VEC_APPLE, { label: 'Apple' });
+    const entry = await db.get(id);
+    expect(entry?.metadata?.label).toBe('Apple');
+  });
+
+  it('updates entries', async () => {
+    const id = await db.add(VEC_BANANA, { label: 'Banana' });
+    await db.update(id, { metadata: { label: 'Updated' } });
+    const updated = await db.get(id);
+    expect(updated?.metadata?.label).toBe('Updated');
+  });
+
+  it('deletes entries', async () => {
+    const id = await db.add(VEC_CHERRY, { label: 'Cherry' });
+    await db.delete(id);
+    const deleted = await db.get(id);
+    expect(deleted).toBeUndefined();
+  });
+
+  it('performs similarity search', async () => {
+    const id1 = await db.add(VEC_APPLE, { label: 'Apple' });
+    await db.add(VEC_BANANA, { label: 'Banana' });
+    await db.add(VEC_CHERRY, { label: 'Cherry' });
+
+    const results = await db.search(QUERY_VEC, 2);
+    expect(results.length).toBe(2);
+    expect(results[0].id).toBe(id1); // Apple should be closest
+  });
+
+  it('rejects dimension mismatch', async () => {
+    const wrong = new Float32Array([1, 2]);
+    await expect(db.add(wrong)).rejects.toThrow();
+  });
+});

--- a/packages/vecal/vite.config.ts
+++ b/packages/vecal/vite.config.ts
@@ -9,4 +9,8 @@ export default defineConfig({
             fileName: (format) => `vecal.${format}.js`,
         },
     },
+    test: {
+        globals: true,
+        environment: 'jsdom',
+    },
 });

--- a/packages/vecal/vitest.config.ts
+++ b/packages/vecal/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Summary
- configure Vitest for browser-style testing
- add VectorDB unit tests

## Testing
- `yarn test` *(fails: package not in lockfile)*