### PR TITLE
Add HN demo using vector DB

### DIFF
--- a/packages/vecal/index.html
+++ b/packages/vecal/index.html
@@ -2,12 +2,24 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + TS</title>
+    <title>Hacker News Explorer</title>
   </head>
   <body>
-    <div id="app"></div>
+    <h1>Hacker News Explorer</h1>
+    <div>
+      <label>OpenAI API Key: <input id="apiKey" type="password"></label>
+      <button id="saveKey">Save Key</button>
+    </div>
+    <div>
+      <button id="loadStories">Load Top Stories</button>
+    </div>
+    <div>
+      <input id="searchInput" placeholder="Search stories" />
+      <button id="searchBtn">Search</button>
+    </div>
+    <div id="status"></div>
+    <ul id="results"></ul>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a simple demo web page
- fetch Hacker News stories, embed titles with OpenAI and index in Vecal
- search indexed stories using OpenAI embeddings
- allow storing OpenAI API key in localStorage

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npx jest`